### PR TITLE
adding entry to lco function for easier install

### DIFF
--- a/lco.py
+++ b/lco.py
@@ -11,7 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import sys
+sys.path.append("../looker_content_observer/")
 import click 
 import logging
 from init_lco import init_lco


### PR DESCRIPTION
Adding lco entry to system path to help fix module not found errors on linux